### PR TITLE
Add --user argument to hide the password from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If a config doesn't contain page.id, you can use ``conf_page_maker`` command
 to create a page and page ID will be put into config automatically.
 
 ```
-usage: conf_publisher [-h] [-u URL] [-a AUTH] [-F] [-w WATERMARK] [-l LINK]
-                      [-ht] [-v]
+usage: conf_publisher [-h] [-u URL] (-a AUTH | -U USER) [-F] [-w WATERMARK]
+                      [-l LINK] [-ht] [-v]
                       config
 
 Publish documentation (Sphinx fjson) to Confluence
@@ -61,6 +61,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -u URL, --url URL     Confluence Url
   -a AUTH, --auth AUTH  Base64 encoded user:password string
+  -U USER, --user USER  Username (prompt password)
   -F, --force           Publish not changed page.
   -w WATERMARK, --watermark WATERMARK
                         Overrides the watermarks. Also can be "False" to
@@ -81,7 +82,8 @@ $ conf_page_maker config.yml --auth XXXXXjpwYXNzdXXXXX== --parent-id 52332132
 ```
 
 ```
-usage: conf_page_maker [-h] [-u URL] [-a AUTH] [-pid PARENT_ID] [-v] config
+usage: conf_page_maker [-h] [-u URL] (-a AUTH | -U USER) [-pid PARENT_ID] [-v]
+                       config
 
 Create Confluence pages and update configuration file with it ids
 
@@ -91,7 +93,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -u URL, --url URL     Confluence Url
-  -a AUTH, --auth AUTH  Base64 encoded user:password string. Required.
+  -a AUTH, --auth AUTH  Base64 encoded user:password string
+  -U USER, --user USER  Username (prompt password)
   -pid PARENT_ID, --parent-id PARENT_ID
                         Parent page ID in confluence.
   -v, --verbose
@@ -101,7 +104,7 @@ optional arguments:
 ## Page dumper
 
 ```
-usage: conf_page_dumper [-h] [-u URL] [-a AUTH] [-o OUTPUT] page_id
+usage: conf_page_dumper [-h] [-u URL] (-a AUTH | -U USER) [-o OUTPUT] page_id
 
 Dumps Confluence page in storage format
 
@@ -112,6 +115,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -u URL, --url URL     Confluence Url
   -a AUTH, --auth AUTH  Base64 encoded user:password string
+  -U USER, --user USER  Username (prompt password)
   -o OUTPUT, --output OUTPUT
                         Output file|stdout|stderr
 ```

--- a/conf_publisher/auth.py
+++ b/conf_publisher/auth.py
@@ -1,0 +1,18 @@
+from sys import version_info
+from base64 import b64encode
+from getpass import getpass
+
+PY3 = version_info.major >= 3
+
+
+def base64(string):
+    if PY3:
+        return b64encode(string.encode('utf8')).decode('utf8')
+    return b64encode(string)
+
+
+def parse_authentication(auth=None, user=None):
+    if user is not None:
+        password = getpass()
+        return base64('%s:%s' % (user, password))
+    return auth

--- a/conf_publisher/page_dumper.py
+++ b/conf_publisher/page_dumper.py
@@ -2,6 +2,7 @@ import argparse
 import codecs
 import sys
 
+from .auth import parse_authentication
 from .confluence_api import create_confluence_api
 from .confluence import ConfluencePageManager
 from .constants import DEFAULT_CONFLUENCE_API_VERSION
@@ -11,12 +12,15 @@ def main():
     parser = argparse.ArgumentParser(description='Dumps Confluence page in storage format')
     parser.add_argument('page_id', type=str, help='Configuration file')
     parser.add_argument('-u', '--url', type=str, help='Confluence Url')
-    parser.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
+    auth_group = parser.add_mutually_exclusive_group(required=True)
+    auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
+    auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
     parser.add_argument('-o', '--output', type=str, help='Output file|stdout|stderr', default='stdout')
 
     args = parser.parse_args()
+    auth = parse_authentication(args.auth, args.user)
 
-    confluence_api = create_confluence_api(DEFAULT_CONFLUENCE_API_VERSION, args.url, args.auth)
+    confluence_api = create_confluence_api(DEFAULT_CONFLUENCE_API_VERSION, args.url, auth)
     page_manager = ConfluencePageManager(confluence_api)
     page = page_manager.load(args.page_id)
 

--- a/conf_publisher/page_maker.py
+++ b/conf_publisher/page_maker.py
@@ -1,6 +1,7 @@
 import argparse
 
 from . import log, setup_logger
+from .auth import parse_authentication
 from .confluence_api import create_confluence_api
 from .constants import DEFAULT_CONFLUENCE_API_VERSION
 from .config import ConfigLoader, ConfigDumper
@@ -58,17 +59,20 @@ def main():
     parser = argparse.ArgumentParser(description='Create Confluence pages and update configuration file with it ids')
     parser.add_argument('config', type=str, help='Configuration file')
     parser.add_argument('-u', '--url', type=str, help='Confluence Url')
-    parser.add_argument('-a', '--auth', type=str, required=True, help='Base64 encoded user:password string. Required.')
+    auth_group = parser.add_mutually_exclusive_group(required=True)
+    auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
+    auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
     parser.add_argument('-pid', '--parent-id', type=str, help='Parent page ID in confluence.')
     parser.add_argument('-v', '--verbose', action='count')
 
     args = parser.parse_args()
+    auth = parse_authentication(args.auth, args.user)
     setup_logger(args.verbose)
 
     config = ConfigLoader.from_yaml(args.config)
     setup_config_overrides(config, args.url)
 
-    confluence_api = create_confluence_api(DEFAULT_CONFLUENCE_API_VERSION, config.url, args.auth)
+    confluence_api = create_confluence_api(DEFAULT_CONFLUENCE_API_VERSION, config.url, auth)
     page_manager = ConfluencePageManager(confluence_api)
     make_pages(config, page_manager, args.parent_id)
 


### PR DESCRIPTION
The password should not appear even as a base64 in the command-line interface. I left to the use to choose between the original option `--auth` and a new option `--user` (mutually exclusive). The `--user` option must contain the username, a prompt will appear for the password (the input is not printed).
