### PR TITLE
Fix python 3 dict iteration

### DIFF
--- a/conf_publisher/serializers/yaml_serializer.py
+++ b/conf_publisher/serializers/yaml_serializer.py
@@ -1,5 +1,6 @@
 import yaml
 from collections import OrderedDict
+import six
 
 
 class OrderedDumper(yaml.Dumper):
@@ -7,7 +8,7 @@ class OrderedDumper(yaml.Dumper):
 
 
 def _dict_representer(dumper, data):
-    return dumper.represent_dict(data.iteritems())
+    return dumper.represent_dict(six.iteritems(data))
 
 OrderedDumper.add_representer(OrderedDict, _dict_representer)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argparse>=1.2.1
 PyYAML>=3.11
 requests>=2.4.3
+six


### PR DESCRIPTION
Added support for python 3 by using six.iteritems. Adds a dependency on six.