### PR TITLE
Authenticate against a server without Basic HTTP auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+confluence_publisher.egg-info/
+

--- a/conf_publisher/auth.py
+++ b/conf_publisher/auth.py
@@ -1,6 +1,7 @@
 from sys import version_info
 from base64 import b64encode
 from getpass import getpass
+import requests
 
 PY3 = version_info.major >= 3
 
@@ -11,8 +12,14 @@ def base64(string):
     return b64encode(string)
 
 
-def parse_authentication(auth=None, user=None):
+def parse_authentication(auth=None, user=None, auth_type="basic"):
     if user is not None:
-        password = getpass()
-        return base64('%s:%s' % (user, password))
+        password = getpass('Enter Confluence password:')
+        if auth_type == "basic":
+            return base64('%s:%s' % (user, password))
+        else:
+            s = requests.Session()
+            s.auth = (user, password)
+            return s
+
     return auth

--- a/conf_publisher/confluence_api.py
+++ b/conf_publisher/confluence_api.py
@@ -32,10 +32,10 @@ class ConfluenceRestApiBase(object):
         if isinstance(auth, basestring):
             log.debug('Using Basic HTTP authentication')
             self.headers['Authorization'] = 'Basic ' + auth
-            self.s = None
+            self.session = None
         else:
             log.debug('Using session authentication')
-            self.s = auth
+            self.session = auth
 
     @staticmethod
     def _build_params(params_map):
@@ -46,24 +46,24 @@ class ConfluenceRestApiBase(object):
         return '/'.join([self.confluence_url, self.api_path] + parts)
 
     def _get(self, url, **kwargs):
-        if self.s is None:
+        if self.session is None:
             return self._request(requests.get, url, **kwargs)
-        return self._request(self.s.get, url, **kwargs)
+        return self._request(self.session.get, url, **kwargs)
 
     def _post(self, url, _json=None, **kwargs):
-        if self.s is None:
+        if self.session is None:
             return self._request(requests.post, url, json=_json, **kwargs)
-        return self._request(self.s.post, url, json=_json, **kwargs)
+        return self._request(self.session.post, url, json=_json, **kwargs)
 
     def _put(self, url, _json=None, **kwargs):
-        if self.s is None:
+        if self.session is None:
             return self._request(requests.put, url, json=_json, **kwargs)
-        return self._request(self.s.put, url, json=_json, **kwargs)
+        return self._request(self.session.put, url, json=_json, **kwargs)
 
     def _delete(self, url, **kwargs):
-        if self.s is None:
+        if self.session is None:
             return self._request(requests.delete, url, **kwargs)
-        return self._request(self.s.delete, url, **kwargs)
+        return self._request(self.session.delete, url, **kwargs)
 
     def _request(self, requester, url, **kwargs):
         if 'headers' not in kwargs:
@@ -229,7 +229,7 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
         headers = {
             'X-Atlassian-Token': 'no-check',
         }
-        if self.s is None:
+        if self.session is None:
             headers['Authorization'] = 'Basic ' + self.auth
 
         params_map = {'comment': comment, 'minorEdit': minor_edits}

--- a/conf_publisher/confluence_api.py
+++ b/conf_publisher/confluence_api.py
@@ -26,8 +26,16 @@ class ConfluenceRestApiBase(object):
         self.auth = auth
         self.headers = {
             'content-type': 'application/json',
-            'Authorization': 'Basic ' + auth
         }
+        # Basic HTTP authentication will use the encoded user:pass which is a string,
+        # otherwise, parse_authentication created a requests.Session object.
+        if isinstance(auth, basestring):
+            log.debug('Using Basic HTTP authentication')
+            self.headers['Authorization'] = 'Basic ' + auth
+            self.s = None
+        else:
+            log.debug('Using session authentication')
+            self.s = auth
 
     @staticmethod
     def _build_params(params_map):
@@ -38,16 +46,24 @@ class ConfluenceRestApiBase(object):
         return '/'.join([self.confluence_url, self.api_path] + parts)
 
     def _get(self, url, **kwargs):
-        return self._request(requests.get, url, **kwargs)
+        if self.s is None:
+            return self._request(requests.get, url, **kwargs)
+        return self._request(self.s.get, url, **kwargs)
 
     def _post(self, url, _json=None, **kwargs):
-        return self._request(requests.post, url, json=_json, **kwargs)
+        if self.s is None:
+            return self._request(requests.post, url, json=_json, **kwargs)
+        return self._request(self.s.post, url, json=_json, **kwargs)
 
     def _put(self, url, _json=None, **kwargs):
-        return self._request(requests.put, url, json=_json, **kwargs)
+        if self.s is None:
+            return self._request(requests.put, url, json=_json, **kwargs)
+        return self._request(self.s.put, url, json=_json, **kwargs)
 
     def _delete(self, url, **kwargs):
-        return self._request(requests.delete, url, **kwargs)
+        if self.s is None:
+            return self._request(requests.delete, url, **kwargs)
+        return self._request(self.s.delete, url, **kwargs)
 
     def _request(self, requester, url, **kwargs):
         if 'headers' not in kwargs:
@@ -212,8 +228,9 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
     def _create_attachment(self, url, attachment, comment=None, minor_edits=False):
         headers = {
             'X-Atlassian-Token': 'no-check',
-            'Authorization': 'Basic ' + self.auth
         }
+        if self.s is None:
+            headers['Authorization'] = 'Basic ' + self.auth
 
         params_map = {'comment': comment, 'minorEdit': minor_edits}
         params = self._build_params(params_map)

--- a/conf_publisher/data_providers/sphinx_html_data_provider.py
+++ b/conf_publisher/data_providers/sphinx_html_data_provider.py
@@ -10,7 +10,8 @@ class SphinxHTMLDataProvider(SphinxBaseDataProvider):
     def get_source_data(self, filename):
         with codecs.open(filename, 'r', encoding='utf-8') as f:
             content = f.read()
-            title = re.findall(r'<title.*?>(.+?)</title>', content)[0]
+            title = re.findall(r'<title.*?>(.+?)</title>', content, re.DOTALL)[0]
+            title = ' '.join([line.strip() for line in title])
             body = re.findall(r'<body.*?>(.+?)</body>', content, re.DOTALL)[0].strip()
 
         return title, body

--- a/conf_publisher/page_dumper.py
+++ b/conf_publisher/page_dumper.py
@@ -15,7 +15,7 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
-    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
+    parser.add_argument('-t', '--auth-type', choices=['basic', 'session'], help='Use "session" for servers with Basic HTTP disabled')
     parser.add_argument('-o', '--output', type=str, help='Output file|stdout|stderr', default='stdout')
 
     args = parser.parse_args()

--- a/conf_publisher/page_dumper.py
+++ b/conf_publisher/page_dumper.py
@@ -15,10 +15,11 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
+    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
     parser.add_argument('-o', '--output', type=str, help='Output file|stdout|stderr', default='stdout')
 
     args = parser.parse_args()
-    auth = parse_authentication(args.auth, args.user)
+    auth = parse_authentication(args.auth, args.user, args.auth_type)
 
     confluence_api = create_confluence_api(DEFAULT_CONFLUENCE_API_VERSION, args.url, auth)
     page_manager = ConfluencePageManager(confluence_api)

--- a/conf_publisher/page_maker.py
+++ b/conf_publisher/page_maker.py
@@ -62,7 +62,7 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
-    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
+    parser.add_argument('-t', '--auth-type', choices=['basic', 'session'], help='Use "session" for servers with Basic HTTP disabled')
     parser.add_argument('-pid', '--parent-id', type=str, help='Parent page ID in confluence.')
     parser.add_argument('-v', '--verbose', action='count')
 

--- a/conf_publisher/page_maker.py
+++ b/conf_publisher/page_maker.py
@@ -62,11 +62,12 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
+    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
     parser.add_argument('-pid', '--parent-id', type=str, help='Parent page ID in confluence.')
     parser.add_argument('-v', '--verbose', action='count')
 
     args = parser.parse_args()
-    auth = parse_authentication(args.auth, args.user)
+    auth = parse_authentication(args.auth, args.user, args.auth_type)
     setup_logger(args.verbose)
 
     config = ConfigLoader.from_yaml(args.config)

--- a/conf_publisher/publish.py
+++ b/conf_publisher/publish.py
@@ -172,6 +172,7 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
+    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
     parser.add_argument('-F', '--force', action='store_true', help='Publish not changed page.')
     parser.add_argument('-w', '--watermark', type=str, help='Overrides the watermarks. Also can be "False" to remove '
                                                             'all watermarks; or "True" to add watermarks'
@@ -181,7 +182,7 @@ def main():
     parser.add_argument('-v', '--verbose', action='count')
 
     args = parser.parse_args()
-    auth = parse_authentication(args.auth, args.user)
+    auth = parse_authentication(args.auth, args.user, args.auth_type)
     setup_logger(args.verbose)
 
     config = ConfigLoader.from_yaml(args.config)

--- a/conf_publisher/publish.py
+++ b/conf_publisher/publish.py
@@ -172,7 +172,7 @@ def main():
     auth_group = parser.add_mutually_exclusive_group(required=True)
     auth_group.add_argument('-a', '--auth', type=str, help='Base64 encoded user:password string')
     auth_group.add_argument('-U', '--user', type=str, help='Username (prompt password)')
-    parser.add_argument('-t', '--auth-type', type=str, help='"basic" or "session" authentication')
+    parser.add_argument('-t', '--auth-type', choices=['basic', 'session'], help='Use "session" for servers with Basic HTTP disabled')
     parser.add_argument('-F', '--force', action='store_true', help='Publish not changed page.')
     parser.add_argument('-w', '--watermark', type=str, help='Overrides the watermarks. Also can be "False" to remove '
                                                             'all watermarks; or "True" to add watermarks'


### PR DESCRIPTION
Our Confluence server does not have Basic HTTP authentication enabled.  Setting the requests.Session user and password allows authentication with our server to work.

I also found that our Sphinx-generated html <title> was multi-line, so I added DOTALL to the regexp.

In order not to change the existing code structure too much, I ended up returning either a string (the base64 encoded user:pass), or the requests.Session object from parse_authentication().  Not sure if this is too weird or not.

I've only lightly tested against our Confluence server, and not against a server with Basic HTTP auth.