### PR TITLE
Use list attachments to get the 50 first attachments, add the mimetype

### DIFF
--- a/conf_publisher/confluence_api.py
+++ b/conf_publisher/confluence_api.py
@@ -174,9 +174,9 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
         params = self._build_params(params_map)
 
         ret = self._get(url, params=params)
-        return ret
+        return ret['results']
 
-    def create_attachment(self, content_id, attachment, comment=None, minor_edits=False):
+    def create_attachment(self, content_id, attachment, comment=None, minor_edits=False, media_type=None, filename=None):
         """
         Add one or more attachments to a Confluence Content entity, with optional comments.
 
@@ -189,7 +189,7 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
         :return:
         """
         url = self._construct_url('content', content_id, 'child', 'attachment')
-        ret = self._create_attachment(url, attachment, comment, minor_edits)
+        ret = self._create_attachment(url, attachment, comment, minor_edits, media_type, filename)
         return ret
 
     def update_attachment_data(self, content_id, attachment_id, attachment, comment=None, minor_edits=False):
@@ -209,7 +209,7 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
         ret = self._create_attachment(url, attachment, comment, minor_edits)
         return ret
 
-    def _create_attachment(self, url, attachment, comment=None, minor_edits=False):
+    def _create_attachment(self, url, attachment, comment=None, minor_edits=False, media_type=None, filename=None):
         headers = {
             'X-Atlassian-Token': 'no-check',
             'Authorization': 'Basic ' + self.auth
@@ -218,5 +218,5 @@ class ConfluenceRestApi553(ConfluenceRestApiBase):
         params_map = {'comment': comment, 'minorEdit': minor_edits}
         params = self._build_params(params_map)
 
-        ret = self._post(url, files={'file': attachment}, data=params, headers=headers)
+        ret = self._post(url, files={'file': (filename, attachment, media_type)}, data=params, headers=headers)
         return ret


### PR DESCRIPTION
The following changes have been done in order to publish content on an Atlassian Cloud Confluence instance (Confluence 1000.904.0).

In `confluence.py` the `publish` function  of the `AttachmentPublisher` has been modified:
- it allows to list 50 attachments by page and so alleviate the current limit of 25 attachments by page. It does this by calling the `_api.list_attachments` method instead of `_get_page_metadata`. The former return 50 attachments by default and the later 25 on my Confluence instance. The limit of 50 is a default set by the signature of `_api.list_attachments`, it could be changed or configurable. The check for existing attachments could be improved.
- the mime type of each attachment is now computed from the filename
- the mime type and the filename of each attachment is now also sent to `_api.create_attachment` and subsequently to `_api._create_attachment`.

In `confluence_api.py`, the `_create_attachment` method now send the mime-type, the binary data and the name of each attachment to the Confluence REST API.

Also in `confluence_api.py`, the return type of `list_attachments` has been changed to return only the `results` part of the response of the REST API. Perhaps it is not advisable, but i have seen no other use of the `_api.list_attachments` method in the code than in the new implementation of `AttachmentPublisher.publish` proposed here.

I hope to not have broke anything with previous versions of Confluence, and should probably create a new ConfluenceRestApi, let me know.

Thanks for your time,
Best regards.